### PR TITLE
Fix non-initialised memory bug

### DIFF
--- a/mpsort-mpi.c
+++ b/mpsort-mpi.c
@@ -109,7 +109,7 @@ static struct TIMER {
 } _TIMERS[512];
 
 static int
-_assign_colors(size_t glocalsize, size_t * sizes, size_t * outsizes, int * ncolor, MPI_Comm comm)
+_assign_colors(size_t glocalsize, size_t * sizes, int * ncolor, MPI_Comm comm)
 {
     int NTask;
     int ThisTask;
@@ -119,12 +119,10 @@ _assign_colors(size_t glocalsize, size_t * sizes, size_t * outsizes, int * ncolo
     int i;
     int mycolor = -1;
     size_t current_size = 0;
-    size_t current_outsize = 0;
     int current_color = 0;
     int lastcolor = 0;
     for(i = 0; i < NTask; i ++) {
         current_size += sizes[i];
-        current_outsize += outsizes[i];
 
         lastcolor = current_color;
 
@@ -132,14 +130,13 @@ _assign_colors(size_t glocalsize, size_t * sizes, size_t * outsizes, int * ncolo
             mycolor = lastcolor;
         }
 
-        if(current_size > glocalsize || current_outsize > glocalsize) {
+        if(current_size > glocalsize) {
             current_size = 0;
-            current_outsize = 0;
             current_color ++;
         }
     }
     /* no data for color of -1; exclude them later with special cases */
-    if(sizes[ThisTask] == 0 && outsizes[ThisTask] == 0) {
+    if(sizes[ThisTask] == 0) {
         mycolor = -1;
     }
 
@@ -225,14 +222,13 @@ MPIU_GetLoc(const void * base, MPI_Datatype type, MPI_Op op, MPI_Comm comm)
 }
 
 static void
-_create_segment_group(struct SegmentGroupDescr * descr, size_t * sizes, size_t * outsizes, size_t avgsegsize, int Ngroup, MPI_Comm comm)
+_create_segment_group(struct SegmentGroupDescr * descr, size_t * sizes, size_t avgsegsize, int Ngroup, MPI_Comm comm)
 {
     int ThisTask, NTask;
 
     MPI_Comm_size(comm, &NTask);
     MPI_Comm_rank(comm, &ThisTask);
-
-    descr->ThisSegment = _assign_colors(avgsegsize, sizes, outsizes, &descr->Nsegments, comm);
+    descr->ThisSegment = _assign_colors(avgsegsize, sizes, &descr->Nsegments, comm);
 
     if(descr->ThisSegment >= 0) {
         /* assign segments to groups.
@@ -391,7 +387,6 @@ mpsort_mpi_newarray_impl (void * mybase, size_t mynmemb,
     }
 
     size_t sizes[NTask];
-    size_t outsizes[NTask];
     size_t myoffset;
     size_t totalsize = _collect_sizes(mynmemb, sizes, &myoffset, comm);
 
@@ -420,7 +415,7 @@ mpsort_mpi_newarray_impl (void * mybase, size_t mynmemb,
     }
 
     /* use as many groups as possible (some will be empty) but at most 1 segment per group */
-    _create_segment_group(seggrp, sizes, outsizes, avgsegsize, NTask, comm);
+    _create_segment_group(seggrp, sizes, avgsegsize, NTask, comm);
 
     /* group comm == seg comm */
 


### PR DESCRIPTION
_assign_colors had an argument, outsizes, which was not initialized

outsizes was passed down to _assign_colors without being initialized. It
was never used after that function, but within that function it could be
used to set avoid setting mycolor = -1. This didn't show up when it was
a stack-allocated VLA (perhaps it was being zerod by virtue of being on
the same page as sizes?) but when I made it malloc'd it caused a test
failure.

Remove this argument to the functions instead of just memsetting it
as it is not used and I could not figure out what it was for.

This is the root cause of the bugs where sparse data fails to sort!