### PR TITLE
Add pyproject.toml specifying build time dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "cython", "mpi4py"]


### PR DESCRIPTION
Add `pyproject.toml` with `[build-system] requires` specifying dependencies which need to be present *before* `setup.py` is run, cf. [PEP 518](python.org/dev/peps/pep-0518). Note that this only handles the install dependencies when using pip, running `python3 setup.py install` will still fail.

Fixes #12, allowing packages which depend on `mpsort` to install it without having to always ensure that `numpy`, `cython`, and `mpi4py` are present *before* installation happens. 